### PR TITLE
Trim fix

### DIFF
--- a/pub/js/thingler.js
+++ b/pub/js/thingler.js
@@ -191,7 +191,7 @@ input.parentNode.on('focus', function () { this.addClass('focused') })
                 .on('blur',  function () { this.removeClass('focused') });
 
 function parseTitle(str) {
-    return str.replace(/&/, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').trim();
+    return str.replace(/&/, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/^\s+|\s+$/, '');
 }
 
 //


### PR DESCRIPTION
Some browsers don't have trim() implemented (e.g. my Android browser). Replaced it with a regular expression.
